### PR TITLE
feat: do not trigger NProgress when new URL starts with "blob:"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -147,8 +147,10 @@ const NextTopLoader = ({
           const currentUrl = window.location.href;
           const newUrl = (anchor as HTMLAnchorElement).href;
           const isExternalLink = (anchor as HTMLAnchorElement).target === "_blank";
+          const isBlob = newUrl.startsWith('blob:');
           const isAnchor = isAnchorOfCurrentUrl(currentUrl, newUrl);
-          if (newUrl === currentUrl || isAnchor || isExternalLink) {
+
+          if (newUrl === currentUrl || isAnchor || isExternalLink || isBlob) {
             NProgress.start();
             NProgress.done();
             [].forEach.call(npgclass, function (el: Element) {


### PR DESCRIPTION
Thanks for making this library. I'm using it in an application which creates a PDF and then changes the URL to a `blob:` link to show the PDF to the user.

This PR adds code that ignores showing the `NProgress` bar when the newUrl starts with `blob:`. Without this code it shows a never ending progress bar.