### PR TITLE
fix: prevent showing progress bar on new tab click

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -169,7 +169,12 @@ const NextTopLoader = ({
           const isExternalLink = (anchor as HTMLAnchorElement).target === '_blank';
           const isBlob = newUrl.startsWith('blob:');
           const isAnchor = isAnchorOfCurrentUrl(currentUrl, newUrl);
-          if (newUrl === currentUrl || isAnchor || isExternalLink || isBlob || event.ctrlKey) {
+          // Check for Ctrl key (Windows/Linux) or Cmd key (Mac)
+          const isModifierKeyPressed = event.ctrlKey || event.metaKey;
+          if (isModifierKeyPressed) {
+            return;
+          }
+          if (newUrl === currentUrl || isAnchor || isExternalLink || isBlob) {
             NProgress.start();
             NProgress.done();
             [].forEach.call(npgclass, function (el: Element) {


### PR DESCRIPTION
This fixes: https://github.com/TheSGJ/nextjs-toploader/issues/53 and also prevents showing the progress bar altogether on a cmd/ctrl click.

The previous code would still briefly show the progress bar (and load endlessly on Mac).