### PR TITLE
fix: resolve progress bar when navigating back from external page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -220,13 +220,21 @@ const NextTopLoader = ({
         NProgress.done();
       }
     }
+    function handlePageHide() {
+      NProgress.done();
+      [].forEach.call(npgclass, function (el: Element) {
+        el.classList.remove('nprogress-busy');
+      });
+    }
 
     // Add the global click event listener
     document.addEventListener('click', handleClick);
+    window.addEventListener('pagehide', handlePageHide);
 
     // Clean up the global click event listener when the component is unmounted
     return () => {
       document.removeEventListener('click', handleClick);
+      window.removeEventListener('pagehide', handlePageHide);
     };
   }, []);
 


### PR DESCRIPTION
## Issue

When users click an external link and then navigate back to the page with the toploader, the progress bar remains stuck in the loading phase and never completes. This issue seems to occur when the page is served from the [bf cache](https://web.dev/articles/bfcache) without actually reloading. 

## Reproduce
The bug can be reproduced on mobile devices and on some desktop browsers, such as Safari on Mac. Framework: Next.js 14.

## Solution
The issue with the toploader can be resolved by attaching to the [pagehide event](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event) and resolve the loader. This approach does not prevent the page from being stored in the bfcache, unlike the unload or beforeunload events.

## Comment
We are using the suggested fix for our website and so far it works perfectly on mobile devices and it should not interfere with the current implementation. Thanks for your work!
