### PR TITLE
Add option to control showing of top loader for hash anchors (fixes #92)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,6 +80,12 @@ export type NextTopLoaderProps = {
    *
    */
   showAtBottom?: boolean;
+  /**
+   * To show the TopLoader for hash anchors.
+   * @default true
+   *
+   */
+  showForHashAnchor?: boolean;
 };
 
 /**
@@ -104,6 +110,7 @@ const NextTopLoader = ({
   template,
   zIndex = 1600,
   showAtBottom = false,
+  showForHashAnchor = true,
 }: NextTopLoaderProps): React.JSX.Element => {
   const defaultColor = '#29d';
   const defaultHeight = 3;
@@ -241,21 +248,26 @@ const NextTopLoader = ({
             newUrl.startsWith(scheme)
           );
 
-          const isAnchor: boolean = isAnchorOfCurrentUrl(currentUrl, newUrl);
           const notSameHost = !isSameHostName(window.location.href, anchor.href);
           if (notSameHost) {
             return;
           }
+
+          const isAnchorOrHashAnchor =
+            isAnchorOfCurrentUrl(currentUrl, newUrl) || isHashAnchor(window.location.href, anchor.href);
+          if (!showForHashAnchor && isAnchorOrHashAnchor) {
+            return;
+          }
+
           if (
             newUrl === currentUrl ||
-            isAnchor ||
             isExternalLink ||
             isSpecialScheme ||
+            isAnchorOrHashAnchor ||
             event.ctrlKey ||
             event.metaKey ||
             event.shiftKey ||
             event.altKey ||
-            isHashAnchor(window.location.href, anchor.href) ||
             !toAbsoluteURL(anchor.href).startsWith('http')
           ) {
             NProgress.start();
@@ -288,10 +300,10 @@ const NextTopLoader = ({
     })((window as Window).history);
 
     /**
- * Complete TopLoader Progress on replacing current entry of history stack
- * @param {History}
- * @returns {void}
- */
+     * Complete TopLoader Progress on replacing current entry of history stack
+     * @param {History}
+     * @returns {void}
+     */
     ((history: History): void => {
       const replaceState = history.replaceState;
       history.replaceState = (...args) => {


### PR DESCRIPTION
## Overview
This change adds a new `showForHashAnchor` to the configuration.
By default this boolean is set to true which is inline with existing / current behaviour.

When set to `false`, the top loader will not be shown for hash anchor links (i.e. `example.com/page#footer`).

## Use case
This feature is useful for websites that make heavy use of hash anchor links.