### PR TITLE
Revert "fix bug: target is customizable"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -242,7 +242,7 @@ const NextTopLoader = ({
         if (newUrl) {
           const currentUrl = window.location.href;
           // const newUrl = (anchor as HTMLAnchorElement).href;
-          const isExternalLink = !!(anchor as HTMLAnchorElement);
+          const isExternalLink = (anchor as HTMLAnchorElement).target === '_blank';
 
           // Check for Special Schemes
           const isSpecialScheme = ['tel:', 'mailto:', 'sms:', 'blob:', 'download:'].some((scheme) =>


### PR DESCRIPTION
Reverts TheSGJ/nextjs-toploader#109

Issue fixed:
Toploader not crawling anymore #122 

When clicking on links, the indication ends instantly, even though the transition has not yet fully occurred.

